### PR TITLE
Prediction API + Test Fixing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -20,20 +20,50 @@
             <artifactId>sqlite-jdbc</artifactId>
             <version>3.42.0.0</version>
         </dependency>
-        
-        <!-- JUnit for testing (optional) -->
+
+        <!-- Jackson Databind: Provides data-binding and JSON serialization/deserialization -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+
+        <!-- Jackson Core: Core functionality required by Jackson Databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+
+        <!-- Jackson Annotations: Supports Jackson-specific annotations like @JsonProperty -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.5.0</version> <!-- Update to the latest version -->
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.5.0</version> <!-- Update to the latest version -->
+            <scope>compile</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
             <version>5.9.3</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
     <build>
@@ -42,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>

--- a/src/main/java/quotify_app/adapters/comparator/ComparatorPresenter.java
+++ b/src/main/java/quotify_app/adapters/comparator/ComparatorPresenter.java
@@ -23,7 +23,7 @@ public class ComparatorPresenter implements ComparatorOutputBoundary {
     @Override
     public void goToCurrentPrice() {
         // Transition to current price view
-        viewManagerModel.setState("currentPrice");
+        viewManagerModel.setState("current price");
         viewManagerModel.firePropertyChanged();
     }
 

--- a/src/main/java/quotify_app/app/AppBuilder.java
+++ b/src/main/java/quotify_app/app/AppBuilder.java
@@ -8,12 +8,14 @@ import javax.swing.WindowConstants;
 
 import quotify_app.adapters.ViewManagerModel;
 import quotify_app.app.factories.ComparatorFactory;
-import quotify_app.app.factories.FunctionFactory;
 import quotify_app.app.factories.CurrentPriceFactory;
+import quotify_app.app.factories.FunctionFactory;
 import quotify_app.app.factories.FuturePriceFactory;
 import quotify_app.app.factories.LoginFactory;
 import quotify_app.app.factories.SignupFactory;
 import quotify_app.data_access.DBUserDataAccessObject;
+import quotify_app.data_access.PredictionClient;
+import quotify_app.data_access.PredictionDataAccessObject;
 import quotify_app.entities.CommonUserFactory;
 import quotify_app.ui.ViewManager;
 
@@ -35,6 +37,8 @@ public class AppBuilder {
 
     public AppBuilder() {
         cardPanel.setLayout(cardLayout);
+        final PredictionClient predictionClient = new PredictionClient();
+        final PredictionDataAccessObject predictionDataAccess = new PredictionDataAccessObject(predictionClient);
         final DBUserDataAccessObject userDataAccessObject = new DBUserDataAccessObject(new CommonUserFactory());
         loginFactory.setUpController(signupFactory, viewManagerModel, userDataAccessObject);
         signupFactory.setUpController(loginFactory, viewManagerModel, userDataAccessObject);
@@ -89,6 +93,7 @@ public class AppBuilder {
                 functionFactory.getFunctionView().getViewName());
         return this;
     }
+
     /**
      * Adds the CurrentPrice View to the application.
      * @return this builder
@@ -127,6 +132,7 @@ public class AppBuilder {
         comparatorFactory.getComparatorView().setComparatorController(comparatorFactory.getComparatorController());
         return this;
     }
+
     /**
      * Adds the CurrentPrice Use Case to the application.
      * @return this builder
@@ -171,7 +177,7 @@ public class AppBuilder {
 
         // Setting the initial view to SignupView
 
-        viewManagerModel.setState(signupFactory.getSignupView().getViewName());
+        viewManagerModel.setState(functionFactory.getFunctionView().getViewName());
         viewManagerModel.firePropertyChanged();
         return application;
     }

--- a/src/main/java/quotify_app/data_access/DBUserDataAccessObject.java
+++ b/src/main/java/quotify_app/data_access/DBUserDataAccessObject.java
@@ -17,6 +17,7 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface, Lo
 
     private final UserFactory userFactory;
     private String currentUsername;
+    private final int three = 3;
 
     public DBUserDataAccessObject(UserFactory userFactory) {
         this.userFactory = userFactory;
@@ -128,7 +129,7 @@ public class DBUserDataAccessObject implements SignupUserDataAccessInterface, Lo
             stmt.setString(1, user.getName());
             // Assumes User has an getEmail() method.
             stmt.setString(2, user.getEmail());
-            stmt.setString(3, user.getPassword());
+            stmt.setString(three, user.getPassword());
             stmt.executeUpdate();
             System.out.println("User " + user.getName() + " saved successfully.");
         }

--- a/src/main/java/quotify_app/data_access/HttpClientWrapper.java
+++ b/src/main/java/quotify_app/data_access/HttpClientWrapper.java
@@ -1,0 +1,29 @@
+package quotify_app.data_access;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * A wrapper class for {@link HttpClient} to abstract its functionality.
+ */
+public class HttpClientWrapper {
+    private final HttpClient client;
+
+    public HttpClientWrapper() {
+        this.client = HttpClient.newHttpClient();
+    }
+
+    /**
+     * Sends an HTTP request and retrieves the response.
+     *
+     * @param request The {@link HttpRequest} to send.
+     * @return The {@link HttpResponse} containing the response.
+     * @throws IOException If an I/O error occurs when sending or receiving.
+     * @throws InterruptedException If the operation is interrupted.
+     */
+    public HttpResponse<String> send(HttpRequest request) throws IOException, InterruptedException {
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/src/main/java/quotify_app/data_access/PredictionClient.java
+++ b/src/main/java/quotify_app/data_access/PredictionClient.java
@@ -2,7 +2,6 @@ package quotify_app.data_access;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
@@ -16,12 +15,12 @@ import quotify_app.entities.PredictionRequest;
  */
 public class PredictionClient {
     private static final String PREDICT_ENDPOINT = "https://housing-prediction-api-62e3f0c37c7d.herokuapp.com/predict";
-    private final HttpClient client;
+    private final HttpClientWrapper client;
     private final ObjectMapper objectMapper;
     private final int okCode = 200;
 
     public PredictionClient() {
-        this.client = HttpClient.newHttpClient();
+        this.client = new HttpClientWrapper();
         this.objectMapper = new ObjectMapper();
     }
 
@@ -45,7 +44,7 @@ public class PredictionClient {
                     .build();
 
             // Send HTTP request and get the response
-            final HttpResponse<String> response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            final HttpResponse<String> response = client.send(httpRequest);
 
             // Check HTTP status code and handle errors
             if (response.statusCode() != okCode) {

--- a/src/main/java/quotify_app/data_access/PredictionClient.java
+++ b/src/main/java/quotify_app/data_access/PredictionClient.java
@@ -1,0 +1,66 @@
+package quotify_app.data_access;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import quotify_app.data_access.exceptions.PredictionClientException;
+import quotify_app.entities.PredictionRequest;
+
+/**
+ * A client for interacting with the Housing Price Prediction API.
+ */
+public class PredictionClient {
+    private static final String PREDICT_ENDPOINT = "https://housing-prediction-api-62e3f0c37c7d.herokuapp.com/predict";
+    private final HttpClient client;
+    private final ObjectMapper objectMapper;
+    private final int okCode = 200;
+
+    public PredictionClient() {
+        this.client = HttpClient.newHttpClient();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Sends a prediction request to the housing price prediction API.
+     *
+     * @param request The {@link PredictionRequest} object containing input data.
+     * @return The prediction response as a JSON string.
+     * @throws PredictionClientException If there is an error during the request or response processing.
+     */
+    public String predict(final PredictionRequest request) throws PredictionClientException {
+        try {
+            // Convert PredictionRequest to JSON
+            final String jsonRequest = objectMapper.writeValueAsString(request);
+
+            // Create HTTP POST request
+            final HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(PREDICT_ENDPOINT))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonRequest))
+                    .build();
+
+            // Send HTTP request and get the response
+            final HttpResponse<String> response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+            // Check HTTP status code and handle errors
+            if (response.statusCode() != okCode) {
+                throw new PredictionClientException(
+                        "Failed to predict. HTTP status: " + response.statusCode() + ". Response: " + response.body()
+                );
+            }
+
+            return response.body();
+        }
+        catch (PredictionClientException | JsonProcessingException err) {
+            throw new PredictionClientException("An error occurred while making the prediction request.", err);
+        }
+        catch (IOException | InterruptedException err) {
+            throw new PredictionClientException(err.getMessage());
+        }
+    }
+}

--- a/src/main/java/quotify_app/data_access/PredictionDataAccessObject.java
+++ b/src/main/java/quotify_app/data_access/PredictionDataAccessObject.java
@@ -87,7 +87,7 @@ public class PredictionDataAccessObject {
         final String geoidv4 = property.getIdentifier().getGeoIdV4().get("ZI");
         final Summary summary = property.getSummary();
 
-        final int propertyAge = 2022 - summary.getYearBuilt();
+        final int propertyAge = currYear - summary.getYearBuilt();
 
         return PredictionRequest.requestBuilder()
                 .beds(summary.getBeds())
@@ -103,10 +103,20 @@ public class PredictionDataAccessObject {
                 .build();
     }
 
+    /**
+     * Returns a value representing the predicted price for the property at the current time.
+     * @return the double value representing the prediction.
+     */
     public double getCurrentPricePredictionString() {
         return currentPricePrediction;
     }
 
+    /**
+     * Returns an array of 6 values representing the predicted price for the property from the present until
+     * 6 months from the present.
+     *
+     * @return the double array returned, where arr[0] is the current prediction, arr[1] is 1 month prediction, etc.
+     */
     public double[] getFuturePredictionsArray() {
         return futurePredictions;
     }

--- a/src/main/java/quotify_app/data_access/PredictionDataAccessObject.java
+++ b/src/main/java/quotify_app/data_access/PredictionDataAccessObject.java
@@ -1,0 +1,113 @@
+package quotify_app.data_access;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import quotify_app.data_access.exceptions.PredictionClientException;
+import quotify_app.entities.PredictionRequest;
+import quotify_app.entities.regionEntities.Property;
+import quotify_app.entities.regionEntities.Summary;
+
+/**
+ * A Data Access Object for handling predictions via PredictionClient and managing prediction data.
+ */
+public class PredictionDataAccessObject {
+    private final int currYear = 2022;
+    private final int currMonth = 12;
+    private final int numFuturePredictions = 6;
+    private final PredictionClient predictionClient;
+    private double currentPricePrediction;
+    private final double[] futurePredictions = new double[numFuturePredictions];
+
+    public PredictionDataAccessObject(PredictionClient predictionClient) {
+        this.predictionClient = predictionClient;
+    }
+
+    /**
+     * Makes a prediction for the current price of the given property.
+     *
+     * @param property The property for which to predict the current price.
+     * @return The predicted current price.
+     * @throws PredictionClientException If there is an issue with the prediction request or response.
+     */
+    public double getCurrentPricePrediction(final Property property) throws PredictionClientException {
+        final PredictionRequest request = buildPredictionRequest(property, 0);
+        final String predictionResponse = predictionClient.predict(request);
+
+        try {
+            // Parse the prediction value from the JSON response
+            final Map<String, Double> responseMap = new ObjectMapper().readValue(predictionResponse, Map.class);
+            final double prediction = responseMap.get("prediction");
+
+            // Store the prediction as a string for logging
+            this.currentPricePrediction = prediction;
+
+            return prediction;
+        }
+        catch (JsonProcessingException err) {
+            throw new PredictionClientException("Failed to parse prediction response.", err);
+        }
+    }
+
+    /**
+     * Makes future predictions (0-5 months offset) for the given property.
+     *
+     * @param property The property for which to predict future prices.
+     * @return An array of future predictions (length 6).
+     * @throws PredictionClientException If there is an issue with the prediction requests or responses.
+     */
+    public double[] getFuturePricePredictions(final Property property) throws PredictionClientException {
+        for (int offset = 0; offset < numFuturePredictions; offset++) {
+            final PredictionRequest request = buildPredictionRequest(property, offset);
+            final String predictionResponse = predictionClient.predict(request);
+
+            try {
+                // Parse the prediction value from the JSON response
+                final Map<String, Double> responseMap = new ObjectMapper().readValue(predictionResponse, Map.class);
+                futurePredictions[offset] = responseMap.get("prediction");
+            }
+            catch (JsonProcessingException err) {
+                throw new PredictionClientException("Failed to parse prediction response for offset " + offset, err);
+            }
+        }
+        return futurePredictions;
+    }
+
+    /**
+     * Builds a {@link PredictionRequest} for a given property and month offset.
+     *
+     * @param property    The property for which to make a prediction.
+     * @param monthOffset The month offset for the prediction.
+     * @return A {@link PredictionRequest} object ready to send to the API.
+     * @throws IllegalArgumentException -- yep.
+     */
+    private PredictionRequest buildPredictionRequest(final Property property, final int monthOffset) {
+
+        final String geoidv4 = property.getIdentifier().getGeoIdV4().get("ZI");
+        final Summary summary = property.getSummary();
+
+        final int propertyAge = 2022 - summary.getYearBuilt();
+
+        return PredictionRequest.requestBuilder()
+                .beds(summary.getBeds())
+                .baths(summary.getBaths())
+                .universalsize(summary.getSize())
+                .geoidv4(geoidv4)
+                .propclass(summary.getPropType())
+                .yearbuilt(summary.getYearBuilt())
+                .monthOffset(monthOffset)
+                .propertyage(propertyAge)
+                .year(currYear)
+                .month(currMonth)
+                .build();
+    }
+
+    public double getCurrentPricePredictionString() {
+        return currentPricePrediction;
+    }
+
+    public double[] getFuturePredictionsArray() {
+        return futurePredictions;
+    }
+}

--- a/src/main/java/quotify_app/data_access/PredictionDataAccessObjectLiveTest.java
+++ b/src/main/java/quotify_app/data_access/PredictionDataAccessObjectLiveTest.java
@@ -46,6 +46,7 @@ class PredictionDataAccessObjectLiveTest {
             1500,
             2000
     );
+    private final Property property = new Property(identifier, address, summary);
 
     @BeforeEach
     void setUp() {
@@ -58,8 +59,6 @@ class PredictionDataAccessObjectLiveTest {
     void testGetCurrentPricePredictionPass() throws PredictionClientException {
         // Mock property data
 
-        final Property property = new Property(identifier, address, summary);
-
         // Call the live API for current price prediction
         final double prediction = dataAccessObject.getCurrentPricePrediction(property);
 
@@ -71,8 +70,6 @@ class PredictionDataAccessObjectLiveTest {
 
     @Test
     void testGetFuturePricePredictionsPass() throws PredictionClientException {
-
-        final Property property = new Property(identifier, address, summary);
 
         // Call the live API for future price predictions
         final double[] futurePredictions = dataAccessObject.getFuturePricePredictions(property);
@@ -92,8 +89,6 @@ class PredictionDataAccessObjectLiveTest {
     @Test
     void testGetCurrentPricePredictionFail() {
         // Mock property data
-
-        final Property property = new Property(identifier, address, summary);
 
         try {
             // Simulate an exception by creating a mock PredictionClient
@@ -122,8 +117,6 @@ class PredictionDataAccessObjectLiveTest {
     void testGetFuturePricePredictionsFail() {
         // Mock property data
 
-        final Property property = new Property(identifier, address, summary);
-
         try {
             // Simulate an exception by creating a mock PredictionClient
             final PredictionClient mockClient = new PredictionClient() {
@@ -151,8 +144,6 @@ class PredictionDataAccessObjectLiveTest {
     void testGetCurrentPricePredictionString() {
         // Mock a successful current price prediction
 
-        final Property property = new Property(identifier, address, summary);
-
         try {
             // Call the live API to populate current price prediction
             dataAccessObject.getCurrentPricePrediction(property);
@@ -172,9 +163,6 @@ class PredictionDataAccessObjectLiveTest {
     @Test
     void testGetFuturePredictionsArray() {
         // Mock a successful future price prediction
-
-        final Property property = new Property(identifier, address, summary);
-
         try {
             // Call the live API to populate future price predictions
             dataAccessObject.getFuturePricePredictions(property);

--- a/src/main/java/quotify_app/data_access/PredictionDataAccessObjectLiveTest.java
+++ b/src/main/java/quotify_app/data_access/PredictionDataAccessObjectLiveTest.java
@@ -1,0 +1,202 @@
+package quotify_app.data_access;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import quotify_app.data_access.exceptions.PredictionClientException;
+import quotify_app.entities.PredictionRequest;
+import quotify_app.entities.regionEntities.Address;
+import quotify_app.entities.regionEntities.Identifier;
+import quotify_app.entities.regionEntities.Property;
+import quotify_app.entities.regionEntities.Summary;
+
+/**
+ * Test class for the PredictionDataAccessObject.
+ */
+class PredictionDataAccessObjectLiveTest {
+    private PredictionDataAccessObject dataAccessObject;
+    private final int numPredictions = 6;
+    private final Address address = new Address(
+            "US",
+            "CA",
+            "San Francisco",
+            "Market St",
+            "123",
+            "94103"
+    );
+    private final Identifier identifier = new Identifier(
+            "123456",
+            Map.of(
+                    "ZI", "00b6f7372d30b75c08e761bf9f975fa4",
+                    "CS", "123",
+                    "ST", "CA",
+                    "CO", "SomeCounty",
+                    "N2", "Neighborhood"
+            )
+    );
+    private final Summary summary = new Summary(
+            "SFR",
+            3,
+            2,
+            "Good",
+            1,
+            1500,
+            2000
+    );
+
+    @BeforeEach
+    void setUp() {
+        // Initialize the real PredictionClient and DataAccessObject
+        final PredictionClient client = new PredictionClient();
+        dataAccessObject = new PredictionDataAccessObject(client);
+    }
+
+    @Test
+    void testGetCurrentPricePredictionPass() throws PredictionClientException {
+        // Mock property data
+
+        final Property property = new Property(identifier, address, summary);
+
+        // Call the live API for current price prediction
+        final double prediction = dataAccessObject.getCurrentPricePrediction(property);
+
+        // Assert that the prediction is a valid numerical value
+        Assertions.assertTrue(prediction > 0, "Prediction should be a positive number");
+        System.out.println("Current Price Prediction: " + prediction);
+
+    }
+
+    @Test
+    void testGetFuturePricePredictionsPass() throws PredictionClientException {
+
+        final Property property = new Property(identifier, address, summary);
+
+        // Call the live API for future price predictions
+        final double[] futurePredictions = dataAccessObject.getFuturePricePredictions(property);
+
+        // Assert that the predictions array has 6 valid numerical values
+        Assertions.assertEquals(numPredictions, futurePredictions.length, "There should be exactly 6 predictions");
+        for (double prediction : futurePredictions) {
+            Assertions.assertTrue(prediction > 0, "Each prediction should be a positive number");
+        }
+        System.out.println("Future Price Predictions: ");
+        for (double prediction : futurePredictions) {
+            System.out.println(prediction);
+        }
+
+    }
+
+    @Test
+    void testGetCurrentPricePredictionFail() {
+        // Mock property data
+
+        final Property property = new Property(identifier, address, summary);
+
+        try {
+            // Simulate an exception by creating a mock PredictionClient
+            final PredictionClient mockClient = new PredictionClient() {
+                @Override
+                public String predict(PredictionRequest request) throws PredictionClientException {
+                    throw new PredictionClientException("Simulated exception in predict()");
+                }
+            };
+
+            // Inject the mock PredictionClient into PredictionDataAccessObject
+            final PredictionDataAccessObject mockDataAccessObject = new PredictionDataAccessObject(mockClient);
+
+            // This should throw an exception
+            mockDataAccessObject.getCurrentPricePrediction(property);
+        }
+        catch (PredictionClientException err) {
+            // Verify that the exception was correctly caught
+            Assertions.assertTrue(err.getMessage().contains("Simulated exception"),
+                    "Unexpected exception message: " + err.getMessage());
+            System.out.println("Caught expected exception: " + err.getMessage());
+        }
+    }
+
+    @Test
+    void testGetFuturePricePredictionsFail() {
+        // Mock property data
+
+        final Property property = new Property(identifier, address, summary);
+
+        try {
+            // Simulate an exception by creating a mock PredictionClient
+            final PredictionClient mockClient = new PredictionClient() {
+                @Override
+                public String predict(PredictionRequest request) throws PredictionClientException {
+                    throw new PredictionClientException("Simulated exception in predict()");
+                }
+            };
+
+            // Inject the mock PredictionClient into PredictionDataAccessObject
+            final PredictionDataAccessObject mockDataAccessObject = new PredictionDataAccessObject(mockClient);
+
+            // This should throw an exception
+            mockDataAccessObject.getFuturePricePredictions(property);
+        }
+        catch (PredictionClientException err) {
+            // Verify that the exception was correctly caught
+            Assertions.assertTrue(err.getMessage().contains("Simulated exception"),
+                    "Unexpected exception message: " + err.getMessage());
+            System.out.println("Caught expected exception: " + err.getMessage());
+        }
+    }
+
+    @Test
+    void testGetCurrentPricePredictionString() {
+        // Mock a successful current price prediction
+
+        final Property property = new Property(identifier, address, summary);
+
+        try {
+            // Call the live API to populate current price prediction
+            dataAccessObject.getCurrentPricePrediction(property);
+
+            // Fetch the current price prediction
+            final double currentPrice = dataAccessObject.getCurrentPricePredictionString();
+
+            // Assert that the returned value matches the expected range
+            Assertions.assertTrue(currentPrice > 0, "Current price prediction should be a positive value");
+            System.out.println("Retrieved Current Price Prediction: " + currentPrice);
+        }
+        catch (PredictionClientException err) {
+            Assertions.fail("Prediction failed: " + err.getMessage());
+        }
+    }
+
+    @Test
+    void testGetFuturePredictionsArray() {
+        // Mock a successful future price prediction
+
+        final Property property = new Property(identifier, address, summary);
+
+        try {
+            // Call the live API to populate future price predictions
+            dataAccessObject.getFuturePricePredictions(property);
+
+            // Fetch the future predictions array
+            final double[] futurePrices = dataAccessObject.getFuturePredictionsArray();
+
+            // Assert that the array has 6 elements, all positive
+            Assertions.assertEquals(numPredictions, futurePrices.length, "The predictions array should have 6 values");
+            for (double price : futurePrices) {
+                Assertions.assertTrue(price > 0, "Each future price prediction should be a positive value");
+            }
+
+            System.out.println("Retrieved Future Price Predictions: ");
+            for (double price : futurePrices) {
+                System.out.println(price);
+            }
+        }
+        catch (PredictionClientException err) {
+            Assertions.fail("Prediction failed: " + err.getMessage());
+        }
+    }
+
+}
+

--- a/src/main/java/quotify_app/data_access/exceptions/PredictionClientException.java
+++ b/src/main/java/quotify_app/data_access/exceptions/PredictionClientException.java
@@ -1,0 +1,14 @@
+package quotify_app.data_access.exceptions;
+
+/**
+ *  Custom exception class for PredictionClient errors.
+ */
+public class PredictionClientException extends Exception {
+    public PredictionClientException(String message) {
+        super(message);
+    }
+
+    public PredictionClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/quotify_app/entities/PredictionRequest.java
+++ b/src/main/java/quotify_app/entities/PredictionRequest.java
@@ -1,0 +1,133 @@
+package quotify_app.entities;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Class that specifies the format a request should take for the prediction model.
+ */
+public final class PredictionRequest {
+    private final int beds;
+    private final int baths;
+    private final double universalsize;
+    private final String geoidv4;
+    private final int propclass;
+    private final int yearbuilt;
+
+    @JsonProperty("month_offset")
+    private final int monthOffset;
+    private final int propertyage;
+    private final int year;
+    private final int month;
+
+    public PredictionRequest(final PredictionRequestBuilder builder) {
+        this.beds = builder.getBeds();
+        this.baths = builder.getBaths();
+        this.universalsize = builder.getUniversalsize();
+        this.geoidv4 = builder.getGeoidv4();
+        this.propclass = builder.getPropclass();
+        this.yearbuilt = builder.getYearbuilt();
+        this.monthOffset = builder.getMonthOffset();
+        this.propertyage = builder.getPropertyage();
+        this.year = builder.getYear();
+        this.month = builder.getMonth();
+    }
+
+    // Getters for all fields
+    public int getBeds() {
+        return beds;
+    }
+
+    public int getBaths() {
+        return baths;
+    }
+
+    public double getUniversalsize() {
+        return universalsize;
+    }
+
+    public String getGeoidv4() {
+        return geoidv4;
+    }
+
+    public int getPropclass() {
+        return propclass;
+    }
+
+    public int getYearbuilt() {
+        return yearbuilt;
+    }
+
+    public int getMonthOffset() {
+        return monthOffset;
+    }
+
+    public int getPropertyage() {
+        return propertyage;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        final boolean result;
+        if (this == o) {
+            result = true;
+        }
+        else if (o == null || getClass() != o.getClass()) {
+            result = false;
+        }
+        else {
+            final PredictionRequest that = (PredictionRequest) o;
+            result = hasEqualBasicFields(that) && hasEqualDerivedFields(that);
+        }
+        return result;
+    }
+
+    private boolean hasEqualBasicFields(final PredictionRequest that) {
+        return beds == that.beds
+                && baths == that.baths
+                && Double.compare(universalsize, that.universalsize) == 0
+                && propclass == that.propclass
+                && Objects.equals(geoidv4, that.geoidv4);
+    }
+
+    private boolean hasEqualDerivedFields(final PredictionRequest that) {
+        return yearbuilt == that.yearbuilt
+                && monthOffset == that.monthOffset
+                && propertyage == that.propertyage
+                && year == that.year
+                && month == that.month;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                beds,
+                baths,
+                universalsize,
+                geoidv4,
+                propclass,
+                yearbuilt,
+                monthOffset,
+                propertyage,
+                year,
+                month
+        );
+    }
+
+    /**
+     * A factory method for the builder.
+     * @return the builder object for the PredictionRequest
+     */
+    public static PredictionRequestBuilder requestBuilder() {
+        return new PredictionRequestBuilder();
+    }
+}

--- a/src/main/java/quotify_app/entities/PredictionRequestBuilder.java
+++ b/src/main/java/quotify_app/entities/PredictionRequestBuilder.java
@@ -1,0 +1,206 @@
+package quotify_app.entities;
+
+/**
+ * A builder for constructing instances of {@link PredictionRequest}.
+ */
+public final class PredictionRequestBuilder {
+    private int beds;
+    private int baths;
+    private double universalsize;
+    private String geoidv4;
+    private int propclass;
+    private int yearbuilt;
+    private int monthOffset;
+    private int propertyage;
+    private int year;
+    private int month;
+
+    /**
+     * Initializes the number of beds for PredictionRequest Objects.
+     * @param numbeds -- the number of beds in this object
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder beds(final int numbeds) {
+        this.beds = numbeds;
+        return this;
+    }
+
+    /**
+     * Initializes the number of baths for PredictionRequest Objects.
+     * @param numbaths -- the number of beds in this object
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder baths(final int numbaths) {
+        this.baths = numbaths;
+        return this;
+    }
+
+    /**
+     * Initializes the universal for PredictionRequest Objects.
+     * @param univsize -- the universalsize of this object
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder universalsize(final double univsize) {
+        this.universalsize = univsize;
+        return this;
+    }
+
+    /**
+     * Initializes the geoid for this PredictionRequest Object.
+     * @param geoidv4init -- the geoid to initialize the object with.
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder geoidv4(final String geoidv4init) {
+        this.geoidv4 = geoidv4init;
+        return this;
+    }
+
+    /**
+     * Initializes the propclass for PredictionRequest Objects.
+     * @param propclassinit -- the propclass for this object
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder propclass(final int propclassinit) {
+        this.propclass = propclassinit;
+        return this;
+    }
+
+    /**
+     * Initializes the yearbuilt for PredictionRequest Objects.
+     * @param yearbuiltinit -- the year built for this predictionrequest object
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder yearbuilt(final int yearbuiltinit) {
+        this.yearbuilt = yearbuiltinit;
+        return this;
+    }
+
+    /**
+     * Initializes the prediction offset for PredictionRequest Objects.
+     * @param monthOffsetinit -- the month at which we want to predict.
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder monthOffset(final int monthOffsetinit) {
+        this.monthOffset = monthOffsetinit;
+        return this;
+    }
+
+    /**
+     * Initializes the property age for PredictionRequest Objects.
+     * @param propertyageinit -- the age of this property.
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder propertyage(final int propertyageinit) {
+        this.propertyage = propertyageinit;
+        return this;
+    }
+
+    /**
+     * Initializes the year for PredictionRequest Objects.
+     * @param yearinit -- the year in which we're making a prediction.
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder year(final int yearinit) {
+        this.year = yearinit;
+        return this;
+    }
+
+    /**
+     * Initializes the month for PredictionRequest Objects.
+     * @param monthinit -- the number of beds in this object
+     * @return -- a pointer to this builder.
+     */
+    public PredictionRequestBuilder month(final int monthinit) {
+        this.month = monthinit;
+        return this;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getBeds() {
+        return beds;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getBaths() {
+        return baths;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    double getUniversalsize() {
+        return universalsize;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    String getGeoidv4() {
+        return geoidv4;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getPropclass() {
+        return propclass;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getYearbuilt() {
+        return yearbuilt;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getMonthOffset() {
+        return monthOffset;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getPropertyage() {
+        return propertyage;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getYear() {
+        return year;
+    }
+
+    /**
+     * Getter function for bed property.
+     * @return integer representing the number of beds.
+     */
+    int getMonth() {
+        return month;
+    }
+
+    /**
+     * Builds a {@link PredictionRequest} instance using the values provided.
+     *
+     * @return a fully constructed {@link PredictionRequest} object
+     */
+    public PredictionRequest build() {
+        return new PredictionRequest(this);
+    }
+}

--- a/src/test/java/usecases/comparator/ComparatorInteractorTest.java
+++ b/src/test/java/usecases/comparator/ComparatorInteractorTest.java
@@ -33,7 +33,7 @@ public class ComparatorInteractorTest {
         comparatorInteractor.goToCurrentPrice();
 
         // Assert
-        assertTrue(viewManagerModel.getState().equals("currentPrice"));
+        assertTrue(viewManagerModel.getState().equals("current price"));
     }
 
     @Test


### PR DESCRIPTION
Adds the predictionClient and PredictionClientDataAccessObject to be used for the future/current price use cases

Integrates these into Appbuilder so they are instantiated along with everything else when the app launched

Adds unit tests for the PredictionDataAccessObject file (NOTE: not 100% line coverage yet because of an issue mocking the behaviour of HTTPclient objects -- will handle later)

Fixes previously added usecase tests for Login, Signup, Comparator, and Function to ensure they have 100% line coverage